### PR TITLE
Fix the issue that DIDPPy docs search does not work

### DIFF
--- a/didppy/docs/conf.py
+++ b/didppy/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autosectionlabel",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.jquery",
 ]
 
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
The problem is due to `sphinx_rtd_theme`: https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
Explicitly add `sphinxcontrib.jquery` to the dependencies as a workaround: