### PR TITLE
Bug about Tables in different dimensions, hotfix-0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "didp-yaml"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "dypdl",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "didppy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dypdl",
  "dypdl-heuristic-search",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "dypdl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "fixedbitset",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "dypdl-heuristic-search"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dypdl",
  "ordered-float",

--- a/didp-yaml/Cargo.toml
+++ b/didp-yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didp-yaml"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.64"
 description = "YAML interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."

--- a/didppy/Cargo.toml
+++ b/didppy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didppy"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.64"
 description = "Python interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."

--- a/dypdl-heuristic-search/Cargo.toml
+++ b/dypdl-heuristic-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl-heuristic-search"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.64"
 description = "Heuristic search solvers for Dynamic Programming Description Language (DyPDL)."

--- a/dypdl/Cargo.toml
+++ b/dypdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.64"
 description = "Libarary for Dynamic Programming Description Language (DyPDL)."


### PR DESCRIPTION
Fixed the bug that a transition using Table3D lead to an existence check on Table2D. In addition, added a set of tests on the transitions using Table1D, Table2D, and Table3D.