### PR TITLE
Hotfix 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "didp-yaml"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "approx",
  "dypdl",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "didppy"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "dypdl",
  "dypdl-heuristic-search",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "dypdl"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "approx",
  "fixedbitset",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "dypdl-heuristic-search"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bus",
  "crossbeam-channel",

--- a/didp-yaml/Cargo.toml
+++ b/didp-yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didp-yaml"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.65"
 description = "YAML interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -12,8 +12,8 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.6.1" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.6.1" }
+dypdl = { path = "../dypdl", version = "0.6.2" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.6.2" }
 rustc-hash = "1.1"
 yaml-rust = "0.4"
 linked-hash-map = "0.5"

--- a/didppy/Cargo.toml
+++ b/didppy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didppy"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.65"
 description = "Python interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -15,8 +15,8 @@ name = "didppy"
 crate-type = ["cdylib"]
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.6.1" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.6.1" }
+dypdl = { path = "../dypdl", version = "0.6.2" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.6.2" }
 rustc-hash = "1.1"
 
 [dependencies.pyo3]

--- a/dypdl-heuristic-search/Cargo.toml
+++ b/dypdl-heuristic-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl-heuristic-search"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.65"
 description = "Heuristic search solvers for Dynamic Programming Description Language (DyPDL)."
@@ -13,7 +13,7 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 
 [dependencies]
 ordered-float = "3.9"
-dypdl = { path = "../dypdl", version = "0.6.1" }
+dypdl = { path = "../dypdl", version = "0.6.2" }
 rustc-hash = "1.1"
 dashmap = "5.5"
 rayon = "1.8"

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search1.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search1.rs
@@ -329,7 +329,12 @@ fn single_sync_beam_search<'a, T, N, M, E, B, V>(
             let mut expanded_all = false;
             let mut sent_all = false;
             let mut received_all = 0;
-            let mut iter = current_beam.drain();
+
+            let mut iter = if parameters.keep_all_layers {
+                current_beam.close_and_drain()
+            } else {
+                current_beam.drain()
+            };
 
             while !sent_all || received_all < threads - 1 {
                 if !expanded_all {

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
@@ -385,7 +385,12 @@ fn single_beam_search<'a, T, N, M, E, B, V>(
             let mut sent_all = false;
             let mut expanded_all = false;
             let mut received_all = 0;
-            let mut iter = current_beam.drain();
+
+            let mut iter = if parameters.keep_all_layers {
+                current_beam.close_and_drain()
+            } else {
+                current_beam.drain()
+            };
 
             while !sent_all || received_all < threads - 1 {
                 if opened < threads - 1 {

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/shared_beam_search.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/shared_beam_search.rs
@@ -175,6 +175,8 @@ where
 
         let goal = thread_pool.install(|| {
             nodes_with_goal_information.par_extend(beam.par_drain(..).filter_map(|node| {
+                node.close();
+
                 if let Some((cost, suffix)) =
                     get_solution_cost_and_suffix(model, &*node, suffix, &base_cost_evaluator)
                 {

--- a/dypdl-heuristic-search/src/search_algorithm/beam_search.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/beam_search.rs
@@ -163,7 +163,13 @@ where
         let mut layer_dual_bound = None;
         let previously_pruned = pruned;
 
-        for node in current_beam.drain() {
+        let drain = if parameters.keep_all_layers {
+            current_beam.close_and_drain()
+        } else {
+            current_beam.drain()
+        };
+
+        for node in drain {
             if let Some(dual_bound) = node.bound(model) {
                 if exceed_bound(model, dual_bound, primal_bound) {
                     continue;

--- a/dypdl/Cargo.toml
+++ b/dypdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.65"
 description = "Libarary for Dynamic Programming Description Language (DyPDL)."
@@ -12,7 +12,7 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ordered-float = "3.7"
+ordered-float = "3.9"
 fixedbitset = "0.4"
 approx = "0.5"
 num-traits = "0.2"


### PR DESCRIPTION
Fix an issue of beam search that happens when `keep_all_layers=true`. Beam search did not work properly in such a case because all nodes in the previous layer were assumed to be in the current beam since they were not closed. 