### PR TITLE
Hotfix 0.7.3

### DIFF
--- a/didp-yaml/Cargo.toml
+++ b/didp-yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didp-yaml"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.65"
 description = "YAML interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -12,8 +12,8 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.7.2" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.7.2" }
+dypdl = { path = "../dypdl", version = "0.7.3" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.7.3" }
 rustc-hash = "1.1"
 yaml-rust = "0.4"
 linked-hash-map = "0.5"

--- a/didppy/Cargo.toml
+++ b/didppy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didppy"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.65"
 description = "Python interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -15,8 +15,8 @@ name = "didppy"
 crate-type = ["cdylib"]
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.7.2" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.7.2" }
+dypdl = { path = "../dypdl", version = "0.7.3" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.7.3" }
 rustc-hash = "1.1"
 
 [dependencies.pyo3]

--- a/dypdl-heuristic-search/Cargo.toml
+++ b/dypdl-heuristic-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl-heuristic-search"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.65"
 description = "Heuristic search solvers for Dynamic Programming Description Language (DyPDL)."
@@ -13,7 +13,7 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 
 [dependencies]
 ordered-float = "3.9"
-dypdl = { path = "../dypdl", version = "0.7.2" }
+dypdl = { path = "../dypdl", version = "0.7.3" }
 rustc-hash = "1.1"
 dashmap = "5.5"
 rayon = "1.8"

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
@@ -410,18 +410,6 @@ fn single_beam_search<'a, T, N, M, E, B, V>(
                             }
                         }
 
-                        if opened == threads - 1 {
-                            if let Some(value) = previous_layer_dual_bound {
-                                if exceed_bound(model, value, primal_bound) {
-                                    best_dual_bound = primal_bound;
-                                } else if best_dual_bound
-                                    .map_or(true, |bound| !exceed_bound(model, bound, Some(value)))
-                                {
-                                    best_dual_bound = Some(value);
-                                }
-                            }
-                        }
-
                         if let Some(other) = information.cost {
                             if !exceed_bound(model, other, cost)
                                 || (Some(other) == cost && information.id < goal_id.unwrap())
@@ -431,6 +419,18 @@ fn single_beam_search<'a, T, N, M, E, B, V>(
 
                                 if !exceed_bound(model, other, primal_bound) {
                                     primal_bound = Some(other);
+                                }
+                            }
+                        }
+                        
+                        if opened == threads - 1 {
+                            if let Some(value) = previous_layer_dual_bound {
+                                if exceed_bound(model, value, primal_bound) {
+                                    best_dual_bound = primal_bound;
+                                } else if best_dual_bound
+                                    .map_or(true, |bound| !exceed_bound(model, bound, Some(value)))
+                                {
+                                    best_dual_bound = Some(value);
                                 }
                             }
                         }

--- a/dypdl/Cargo.toml
+++ b/dypdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.65"
 description = "Libarary for Dynamic Programming Description Language (DyPDL)."


### PR DESCRIPTION
Swap the order of updating primal bound and dual bound to fix the problem of incorrect dual bound when the new primal bound is received from the last previous layer message. 