### PR TITLE
Hotfix 0.10.1

### DIFF
--- a/.github/workflows/didppy.yaml
+++ b/.github/workflows/didppy.yaml
@@ -46,7 +46,7 @@ jobs:
         working-directory: didppy
 
   macos-x86_64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: [rust-test]
     steps:
       - uses: actions/checkout@v4
@@ -275,7 +275,16 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    needs: [macos-x86_64, macos, windows, linux, linux-cross, musllinux, musllinux-cross]
+    needs:
+      [
+        macos-x86_64,
+        macos,
+        windows,
+        linux,
+        linux-cross,
+        musllinux,
+        musllinux-cross,
+      ]
     steps:
       - name: Merge wheels
         uses: actions/upload-artifact/merge@v4

--- a/didp-yaml/Cargo.toml
+++ b/didp-yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didp-yaml"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.65"
 description = "YAML interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -16,8 +16,8 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.10.0" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.10.0" }
+dypdl = { path = "../dypdl", version = "0.10.1" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.10.1" }
 rustc-hash = "2.1"
 yaml-rust = "0.4"
 linked-hash-map = "0.5"

--- a/didppy/Cargo.toml
+++ b/didppy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didppy"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.65"
 description = "Python interface for Dynamic Programming Description Language (DyPDL) and DyPDL solvers."
@@ -19,9 +19,9 @@ name = "didppy"
 crate-type = ["cdylib"]
 
 [dependencies]
-dypdl = { path = "../dypdl", version = "0.10.0" }
-dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.10.0" }
-didp-yaml = { path = "../didp-yaml", version = "0.10.0" }
+dypdl = { path = "../dypdl", version = "0.10.1" }
+dypdl-heuristic-search = { path = "../dypdl-heuristic-search", version = "0.10.1" }
+didp-yaml = { path = "../didp-yaml", version = "0.10.1" }
 rustc-hash = "2.1"
 yaml-rust = "0.4"
 

--- a/didppy/pyproject.toml
+++ b/didppy/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Yuxiao (Jasper) Chen", email = "yuxiao.chen@mail.utoronto.ca" },
     { name = "Anubhav Singh", email = "anubhav.singh@utoronto.ca" },
 ]
-version = "0.10.0"
+version = "0.10.1"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",

--- a/dypdl-heuristic-search/Cargo.toml
+++ b/dypdl-heuristic-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl-heuristic-search"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.65"
 description = "Heuristic search solvers for Dynamic Programming Description Language (DyPDL)."
@@ -17,7 +17,7 @@ repository = "https://github.com/domain-independent-dp/didp-rs"
 
 [dependencies]
 ordered-float = "5.0"
-dypdl = { path = "../dypdl", version = "0.10.0" }
+dypdl = { path = "../dypdl", version = "0.10.1" }
 rustc-hash = "2.1"
 dashmap = "6.1"
 rayon = "1.10"

--- a/dypdl-heuristic-search/src/caasdy.rs
+++ b/dypdl-heuristic-search/src/caasdy.rs
@@ -1,10 +1,10 @@
-use crate::search_algorithm::data_structure::{ParentAndChildStateFunctionCache, TransitionWithId};
+use crate::search_algorithm::data_structure::{TransitionWithId};
 
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     BestFirstSearch, CostNode, FNode, Parameters, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type,ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -125,7 +125,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(
             BestFirstSearch::<_, CostNode<_, TransitionWithId>, _, _>::new(
                 input,

--- a/dypdl-heuristic-search/src/dual_bound_acps.rs
+++ b/dypdl-heuristic-search/src/dual_bound_acps.rs
@@ -1,11 +1,9 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     Acps, CostNode, FNode, Parameters, ProgressiveSearchParameters, Search, SearchInput,
     SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -127,7 +125,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(Acps::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/dual_bound_apps.rs
+++ b/dypdl-heuristic-search/src/dual_bound_apps.rs
@@ -1,11 +1,9 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     Apps, CostNode, FNode, Parameters, ProgressiveSearchParameters, Search, SearchInput,
     SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -127,7 +125,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(Apps::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/dual_bound_breadth_first_search.rs
+++ b/dypdl-heuristic-search/src/dual_bound_breadth_first_search.rs
@@ -1,10 +1,8 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     BreadthFirstSearch, BrfsParameters, CostNode, FNode, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -120,7 +118,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(BreadthFirstSearch::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/dual_bound_cabs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_cabs.rs
@@ -1,10 +1,8 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     beam_search, Cabs, CabsParameters, CostNode, FNode, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -124,7 +122,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_successor_node(transition, &mut cache.parent, &model)
+            node.generate_successor_node(transition, cache, &model)
         };
         let beam_search = move |input: &SearchInput<_, _>, parameters| {
             beam_search(

--- a/dypdl-heuristic-search/src/dual_bound_cahdbs1.rs
+++ b/dypdl-heuristic-search/src/dual_bound_cahdbs1.rs
@@ -1,11 +1,11 @@
-use crate::search_algorithm::data_structure::{ParentAndChildStateFunctionCache, TransitionWithId};
+use crate::search_algorithm::data_structure::TransitionWithId;
 
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{hd_beam_search1, CostNodeMessage, FNodeMessage};
 use super::search_algorithm::{
     Cabs, CabsParameters, CostNode, FNode, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -148,7 +148,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_sendable_successor_node(transition, &mut cache.parent, &model)
+            node.generate_sendable_successor_node(transition, cache, &model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             let (solution, statistics) = hd_beam_search1(

--- a/dypdl-heuristic-search/src/dual_bound_cahdbs2.rs
+++ b/dypdl-heuristic-search/src/dual_bound_cahdbs2.rs
@@ -1,11 +1,11 @@
-use crate::search_algorithm::data_structure::{ParentAndChildStateFunctionCache, TransitionWithId};
+use crate::search_algorithm::data_structure::TransitionWithId;
 
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{hd_beam_search2, CostNodeMessage, FNodeMessage};
 use super::search_algorithm::{
     Cabs, CabsParameters, CostNode, FNode, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -148,7 +148,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_sendable_successor_node(transition, &mut cache.parent, &model)
+            node.generate_sendable_successor_node(transition, cache, &model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             let (solution, statistics) = hd_beam_search2(

--- a/dypdl-heuristic-search/src/dual_bound_casbs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_casbs.rs
@@ -1,11 +1,11 @@
 use crate::search_algorithm::data_structure::{
-    HashableSignatureVariables, ParentAndChildStateFunctionCache, TransitionWithId,
+    HashableSignatureVariables, TransitionWithId,
 };
 
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{shared_beam_search, SendableCostNode, SendableFNode};
 use super::search_algorithm::{Cabs, CabsParameters, Search, SearchInput, SuccessorGenerator};
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -141,7 +141,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_successor_node(transition, &mut cache.parent, &model)
+            node.generate_successor_node(transition, cache, &model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             shared_beam_search(

--- a/dypdl-heuristic-search/src/dual_bound_cbfs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_cbfs.rs
@@ -1,10 +1,8 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     Cbfs, CostNode, FNode, Parameters, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -120,7 +118,7 @@ where
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          registry: &mut _,
                                          _| {
-            node.insert_successor_node(transition, &mut cache.parent, registry)
+            node.insert_successor_node(transition, cache, registry)
         };
         Box::new(Cbfs::<_, CostNode<_>, _, _>::new(
             input,

--- a/dypdl-heuristic-search/src/dual_bound_dbdfs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_dbdfs.rs
@@ -1,10 +1,8 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     CostNode, Dbdfs, DbdfsParameters, FNode, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -119,7 +117,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(Dbdfs::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/dual_bound_dd_lns.rs
+++ b/dypdl-heuristic-search/src/dual_bound_dd_lns.rs
@@ -1,10 +1,10 @@
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
-    beam_search, data_structure::ParentAndChildStateFunctionCache, rollout, Cabs, CabsParameters,
+    beam_search, rollout, Cabs, CabsParameters,
     CostNode, DdLns, DdLnsParameters, FNode, NeighborhoodSearchInput, Search, SearchInput,
     Solution, StateInRegistry, SuccessorGenerator, TransitionMutex, TransitionWithId,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -252,7 +252,7 @@ where
                                              transition,
                                              cache: &mut ParentAndChildStateFunctionCache,
                                              _| {
-                node.generate_successor_node(transition, &mut cache.parent, &t_model)
+                node.generate_successor_node(transition, cache, &t_model)
             };
             let input = SearchInput {
                 node: node_generator(StateInRegistry::from(model.target.clone()), root_cost),
@@ -277,7 +277,7 @@ where
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          registry: &mut _,
                                          _| {
-            node.insert_successor_node(transition, &mut cache.parent, registry)
+            node.insert_successor_node(transition, cache, registry)
         };
         parameters.beam_search_parameters.parameters.time_limit = parameters
             .beam_search_parameters

--- a/dypdl-heuristic-search/src/dual_bound_dfbb.rs
+++ b/dypdl-heuristic-search/src/dual_bound_dfbb.rs
@@ -1,10 +1,8 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     CostNode, Dfbb, FNode, Parameters, Search, SearchInput, SuccessorGenerator,
 };
-use dypdl::{variable_type, StateFunctionCache, Transition};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -117,7 +115,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(Dfbb::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/dual_bound_lnbs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_lnbs.rs
@@ -1,12 +1,12 @@
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
-    beam_search, data_structure::ParentAndChildStateFunctionCache, rollout, Cabs, CabsParameters,
+    beam_search, rollout, Cabs, CabsParameters,
     CostNode, FNode, Lnbs, LnbsParameters, NeighborhoodSearchInput, Search, SearchInput,
     StateInRegistry, SuccessorGenerator, TransitionMutex, TransitionWithId,
 };
 use super::Solution;
 use dypdl::variable_type;
-use dypdl::{StateFunctionCache, Transition};
+use dypdl::{ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -241,7 +241,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_successor_node(transition, &mut cache.parent, &t_model)
+            node.generate_successor_node(transition, cache, &t_model)
         };
         let beam_search = move |input: &SearchInput<_, _>, parameters| {
             beam_search(

--- a/dypdl-heuristic-search/src/dual_bound_lnhdbs1.rs
+++ b/dypdl-heuristic-search/src/dual_bound_lnhdbs1.rs
@@ -1,13 +1,12 @@
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{hd_beam_search2, CostNodeMessage, FNodeMessage};
-use super::search_algorithm::{
-    data_structure::ParentAndChildStateFunctionCache, rollout, Cabs, CabsParameters, CostNode,
+use super::search_algorithm::{rollout, Cabs, CabsParameters, CostNode,
     FNode, Lnbs, LnbsParameters, NeighborhoodSearchInput, Search, SearchInput, StateInRegistry,
     SuccessorGenerator, TransitionMutex, TransitionWithId,
 };
 use super::Solution;
 use dypdl::variable_type;
-use dypdl::{StateFunctionCache, Transition};
+use dypdl::{ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -256,7 +255,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_sendable_successor_node(transition, &mut cache.parent, &t_model)
+            node.generate_sendable_successor_node(transition, cache, &t_model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             let (solution, _) = hd_beam_search2(

--- a/dypdl-heuristic-search/src/dual_bound_lnhdbs2.rs
+++ b/dypdl-heuristic-search/src/dual_bound_lnhdbs2.rs
@@ -1,13 +1,12 @@
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{hd_beam_search2, CostNodeMessage, FNodeMessage};
-use super::search_algorithm::{
-    data_structure::ParentAndChildStateFunctionCache, rollout, Cabs, CabsParameters, CostNode,
+use super::search_algorithm::{rollout, Cabs, CabsParameters, CostNode,
     FNode, Lnbs, LnbsParameters, NeighborhoodSearchInput, Search, SearchInput, StateInRegistry,
     SuccessorGenerator, TransitionMutex, TransitionWithId,
 };
 use super::Solution;
 use dypdl::variable_type;
-use dypdl::{StateFunctionCache, Transition};
+use dypdl::{ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -256,7 +255,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_sendable_successor_node(transition, &mut cache.parent, &t_model)
+            node.generate_sendable_successor_node(transition, cache, &t_model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             let (solution, _) = hd_beam_search2(

--- a/dypdl-heuristic-search/src/dual_bound_lnsbs.rs
+++ b/dypdl-heuristic-search/src/dual_bound_lnsbs.rs
@@ -2,14 +2,13 @@ use crate::search_algorithm::data_structure::HashableSignatureVariables;
 
 use super::f_evaluator_type::FEvaluatorType;
 use super::parallel_search_algorithm::{shared_beam_search, SendableCostNode, SendableFNode};
-use super::search_algorithm::{
-    data_structure::ParentAndChildStateFunctionCache, rollout, Cabs, CabsParameters, Lnbs,
+use super::search_algorithm::{rollout, Cabs, CabsParameters, Lnbs,
     LnbsParameters, NeighborhoodSearchInput, Search, SearchInput, StateInRegistry,
     SuccessorGenerator, TransitionMutex, TransitionWithId,
 };
 use super::Solution;
 use dypdl::variable_type;
-use dypdl::{StateFunctionCache, Transition};
+use dypdl::{ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::str;
 use std::sync::Arc;
@@ -260,7 +259,7 @@ where
                                          transition,
                                          cache: &mut ParentAndChildStateFunctionCache,
                                          _| {
-            node.generate_successor_node(transition, &mut cache.parent, &t_model)
+            node.generate_successor_node(transition, cache, &t_model)
         };
         let beam_search = move |input: &SearchInput<_, _, _, _>, parameters| {
             shared_beam_search(

--- a/dypdl-heuristic-search/src/dual_bound_weighted_astar.rs
+++ b/dypdl-heuristic-search/src/dual_bound_weighted_astar.rs
@@ -1,12 +1,10 @@
-use crate::search_algorithm::data_structure::ParentAndChildStateFunctionCache;
-
 use super::f_evaluator_type::FEvaluatorType;
 use super::search_algorithm::{
     BestFirstSearch, CostNode, FNodeEvaluators, Parameters, Search, SearchInput,
     SuccessorGenerator, WeightedFNode,
 };
 use dypdl::variable_type::{Numeric, OrderedContinuous};
-use dypdl::{Continuous, StateFunctionCache, Transition};
+use dypdl::{Continuous, ParentAndChildStateFunctionCache, StateFunctionCache, Transition};
 use std::fmt;
 use std::rc::Rc;
 use std::str;
@@ -135,7 +133,7 @@ where
              transition,
              cache: &mut ParentAndChildStateFunctionCache,
              registry: &mut _,
-             _| { node.insert_successor_node(transition, &mut cache.parent, registry) };
+             _| { node.insert_successor_node(transition, cache, registry) };
         Box::new(BestFirstSearch::<_, CostNode<_>, _, _>::new(
             input,
             transition_evaluator,

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/cost_node_message.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/cost_node_message.rs
@@ -5,7 +5,7 @@ use crate::search_algorithm::data_structure::{
 };
 use crate::search_algorithm::CostNode;
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, ReduceFunction, StateFunctionCache, Transition, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, ReduceFunction, Transition, TransitionInterface};
 use rustc_hash::FxHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -118,7 +118,7 @@ where
 {
     /// Generates a sendable successor node message given a transition and a DyPDL model.
     ///
-    /// `function_cache` is not cleared and updated by this node.
+    /// `function_cache.parent` is not cleared and updated by this node.
     ///
     /// Returns `None` if the successor state is pruned by a state constraint.
     ///
@@ -151,7 +151,7 @@ where
     ///     &model.target, &mut function_cache, &model.state_functions, &model.table_registry
     /// );
     ///
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     /// let node = node.generate_sendable_successor_node(
     ///     Arc::new(transition.clone()), &mut function_cache, &model,
     /// );
@@ -165,10 +165,11 @@ where
     pub fn generate_sendable_successor_node(
         &self,
         transition: Arc<V>,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         model: &Model,
     ) -> Option<CostNodeMessage<T, V>> {
         let cost = self.cost(model);
+        function_cache.child.clear();
         let (state, cost) = model.generate_successor_state(
             self.state(),
             function_cache,
@@ -374,7 +375,7 @@ mod tests {
         );
 
         let node = CostNode::generate_root_node(state, 0, &model);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor = node.generate_sendable_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -419,7 +420,7 @@ mod tests {
         );
 
         let node = CostNode::generate_root_node(state, 0, &model);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor = node.generate_sendable_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -459,7 +460,7 @@ mod tests {
         assert!(result.is_ok());
         transition.set_cost(IntegerExpression::Cost + 1);
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.generate_sendable_successor_node(
             Arc::new(transition),
             &mut function_cache,

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/f_node_message.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/f_node_message.rs
@@ -2,12 +2,12 @@ use super::super::arc_chain::ArcChain;
 use super::cost_node_message::CostNodeMessage;
 use super::search_node_message::SearchNodeMessage;
 use crate::search_algorithm::data_structure::{
-    CreateTransitionChain, ParentAndChildStateFunctionCache, StateInformation,
+    CreateTransitionChain, StateInformation,
     StateWithHashableSignatureVariables, TransitionWithId,
 };
 use crate::search_algorithm::{FNode, FNodeEvaluators};
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, StateFunctionCache, Transition, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, StateFunctionCache, Transition, TransitionInterface};
 use rustc_hash::FxHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -149,9 +149,10 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{FNode, StateInRegistry};
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache,
+    ///     GetTransitions, StateInformation
     /// };
     /// use std::sync::Arc;
     ///
@@ -212,9 +213,10 @@ where
         H: FnOnce(&StateWithHashableSignatureVariables, &mut StateFunctionCache) -> Option<T>,
         F: FnOnce(T, T, &StateWithHashableSignatureVariables) -> T,
     {
+        function_cache.child.clear();
         let (state, g) = model.generate_successor_state(
             self.state(),
-            &mut function_cache.parent,
+            function_cache,
             self.cost(model),
             transition.as_ref(),
             None,

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/sendable_cost_node.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/sendable_cost_node.rs
@@ -6,7 +6,7 @@ use crate::search_algorithm::data_structure::{
 };
 use crate::search_algorithm::{BfsNode, StateInRegistry};
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, ReduceFunction, StateFunctionCache, Transition, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, ReduceFunction, Transition, TransitionInterface};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::sync::atomic;
@@ -99,7 +99,7 @@ where
 
     /// Generates a successor node given a transition and a DyPDL model.
     ///
-    /// `function_cache` is not cleared and updated by this node.
+    /// `function_cache.parent` is not cleared and updated by this node.
     ///
     /// Returns `None` if the successor state is pruned by a state constraint.
     ///
@@ -111,6 +111,7 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::SendableCostNode;
     /// use dypdl_heuristic_search::search_algorithm::StateInRegistry;
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
@@ -141,7 +142,7 @@ where
     ///     &model.table_registry,
     /// );
     ///
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     /// let node = node.generate_successor_node(
     ///     Arc::new(transition.clone()), &mut function_cache, &model,
     /// );
@@ -155,10 +156,11 @@ where
     pub fn generate_successor_node(
         &self,
         transition: Arc<V>,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         model: &Model,
     ) -> Option<Self> {
         let cost = self.cost(model);
+        function_cache.child.clear();
         let (state, cost) = model.generate_successor_state(
             &self.state,
             function_cache,
@@ -173,7 +175,7 @@ where
 
     /// Generates a successor node given a transition and inserts it into a state registry.
     ///
-    /// `function_cache` is not cleared and updated by this node.
+    /// `function_cache.parent` is not cleared and updated by this node.
     ///
     /// Returns the successor node and whether a new entry is generated or not.
     /// If the successor node dominates an existing non-closed node in the registry, the second return value is `false`.
@@ -187,6 +189,7 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::SendableCostNode;
     /// use dypdl_heuristic_search::parallel_search_algorithm::ConcurrentStateRegistry;
     /// use dypdl_heuristic_search::search_algorithm::StateInRegistry;
@@ -219,7 +222,7 @@ where
     ///     &model.target, &mut function_cache, &model.state_functions, &model.table_registry,
     /// );
     ///
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     /// let result = node.insert_successor_node(
     ///     Arc::new(transition.clone()), &mut function_cache, &registry,
     /// );
@@ -234,10 +237,11 @@ where
     pub fn insert_successor_node(
         &self,
         transition: Arc<V>,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         registry: &ConcurrentStateRegistry<T, Self>,
     ) -> Option<(Arc<SendableCostNode<T, V>>, bool)> {
         let model = registry.model();
+        function_cache.child.clear();
         let (state, cost) = model.generate_successor_state(
             self.state(),
             function_cache,
@@ -555,7 +559,7 @@ mod tests {
         );
         let node = SendableCostNode::generate_root_node(state, 0, &model);
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor =
             node.generate_successor_node(Arc::new(transition.clone()), &mut function_cache, &model);
         assert!(successor.is_some());
@@ -596,7 +600,7 @@ mod tests {
         );
 
         let node = SendableCostNode::generate_root_node(state, 0, &model);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor =
             node.generate_successor_node(Arc::new(transition.clone()), &mut function_cache, &model);
         assert!(successor.is_some());
@@ -632,7 +636,7 @@ mod tests {
         assert!(result.is_ok());
         transition.set_cost(IntegerExpression::Cost + 1);
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result =
             node.generate_successor_node(Arc::new(transition), &mut function_cache, &model);
         assert_eq!(result, None);
@@ -677,7 +681,7 @@ mod tests {
         let result = registry.insert(node.clone());
         assert!(result.information.is_some());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -733,7 +737,7 @@ mod tests {
         let result = registry.insert(node.clone());
         assert!(result.information.is_some());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -781,7 +785,7 @@ mod tests {
             id: 0,
         };
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result =
             node.insert_successor_node(Arc::new(transition), &mut function_cache, &registry);
         assert_eq!(result, None);
@@ -828,7 +832,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -886,7 +890,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -935,7 +939,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -976,7 +980,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Arc::new(transition.clone()),
             &mut function_cache,
@@ -1010,7 +1014,7 @@ mod tests {
             forced: false,
             id: 0,
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let node2 =
             node1.generate_successor_node(Arc::new(transition), &mut function_cache, &model);
         assert!(node2.is_some());
@@ -1024,6 +1028,7 @@ mod tests {
             id: 0,
         };
         let registry = ConcurrentStateRegistry::<_, SendableCostNode<_>>::new(Arc::new(model));
+        function_cache.child.clear();
         let result =
             node1.insert_successor_node(Arc::new(transition), &mut function_cache, &registry);
         assert!(result.is_some());
@@ -1064,7 +1069,7 @@ mod tests {
             forced: false,
             id: 0,
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let node2 =
             node1.generate_successor_node(Arc::new(transition), &mut function_cache, &model);
         assert!(node2.is_some());
@@ -1078,6 +1083,7 @@ mod tests {
             id: 0,
         };
         let registry = ConcurrentStateRegistry::<_, SendableCostNode<_>>::new(Arc::new(model));
+        function_cache.child.clear();
         let result =
             node1.insert_successor_node(Arc::new(transition), &mut function_cache, &registry);
         assert!(result.is_some());

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/sendable_f_node.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/search_node/sendable_f_node.rs
@@ -2,11 +2,12 @@ use super::super::arc_chain::ArcChain;
 use super::super::concurrent_state_registry::ConcurrentStateRegistry;
 use crate::search_algorithm::data_structure::{
     exceed_bound, CreateTransitionChain, GetTransitions, HashableSignatureVariables,
-    ParentAndChildStateFunctionCache, StateInformation, TransitionWithId,
+    StateInformation, TransitionWithId
 };
 use crate::search_algorithm::{BfsNode, StateInRegistry};
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, ReduceFunction, StateFunctionCache, Transition, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, ReduceFunction, StateFunctionCache, Transition,
+    TransitionInterface};
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::sync::atomic;
@@ -159,10 +160,11 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::SendableFNode;
     /// use dypdl_heuristic_search::search_algorithm::StateInRegistry;
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId,
     /// };
     /// use std::sync::Arc;
     ///
@@ -223,14 +225,14 @@ where
         ) -> Option<T>,
         F: FnOnce(T, T, &StateInRegistry<Arc<HashableSignatureVariables>>) -> T,
     {
+        function_cache.child.clear();
         let (state, g) = model.generate_successor_state(
             &self.state,
-            &mut function_cache.parent,
+            function_cache,
             self.g,
             transition.as_ref(),
             None,
         )?;
-        function_cache.child.clear();
         let h = h_evaluator(&state, &mut function_cache.child)?;
         let f = f_evaluator(g, h, &state);
 
@@ -277,11 +279,12 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::SendableFNode;
     /// use dypdl_heuristic_search::parallel_search_algorithm::ConcurrentStateRegistry;
     /// use dypdl_heuristic_search::search_algorithm::StateInRegistry;
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId,
     /// };
     /// use std::sync::Arc;
     ///
@@ -343,9 +346,10 @@ where
         ) -> Option<T>,
         F: FnOnce(T, T, &StateInRegistry<Arc<HashableSignatureVariables>>) -> T,
     {
+        function_cache.child.clear();
         let (state, g) = registry.model().generate_successor_state(
             &self.state,
-            &mut function_cache.parent,
+            function_cache,
             self.g,
             transition.as_ref(),
             None,
@@ -362,7 +366,6 @@ where
                     -other.h
                 }
             } else {
-                function_cache.child.clear();
                 h_evaluator(&state, &mut function_cache.child)?
             };
             let f = f_evaluator(g, h, &state);

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/sendable_successor_iterator.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/data_structure/sendable_successor_iterator.rs
@@ -1,12 +1,12 @@
 use crate::search_algorithm::{
     data_structure::{
-        HashableSignatureVariables, ParentAndChildStateFunctionCache, TransitionWithId,
+        HashableSignatureVariables, TransitionWithId
     },
     BfsNode, SuccessorGenerator,
 };
 use crate::ConcurrentStateRegistry;
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, TransitionInterface};
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -168,7 +168,7 @@ mod tests {
         let result = transition.add_effect(var, var + 2);
         assert!(result.is_ok());
         transition.set_cost(IntegerExpression::Cost + 2);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = model.generate_successor_state(
             &model.target,
             &mut function_cache,
@@ -279,7 +279,7 @@ mod tests {
         let result = transition.add_effect(var, var + 3);
         assert!(result.is_ok());
         transition.set_cost(IntegerExpression::Cost + 3);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = model.generate_successor_state(
             &model.target,
             &mut function_cache,
@@ -297,7 +297,7 @@ mod tests {
         let result = transition.add_effect(var, var + 4);
         assert!(result.is_ok());
         transition.set_cost(IntegerExpression::Cost + 4);
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = model.generate_successor_state(
             &model.target,
             &mut function_cache,

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search1.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search1.rs
@@ -3,13 +3,13 @@ use super::hd_search_statistics::{HdSearchResult, HdSearchStatistics};
 use crate::search_algorithm::data_structure::{exceed_bound, Beam};
 use crate::search_algorithm::util::TimeKeeper;
 use crate::search_algorithm::{
-    data_structure::{ParentAndChildStateFunctionCache, TransitionWithId},
+    data_structure::TransitionWithId,
     get_solution_cost_and_suffix, BeamSearchParameters, BfsNode, SearchInput, Solution,
     StateRegistry,
 };
 use bus::{Bus, BusReader};
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
-use dypdl::{variable_type, Model, TransitionInterface};
+use dypdl::{variable_type, Model, ParentAndChildStateFunctionCache, TransitionInterface};
 use std::error::Error;
 use std::fmt::Display;
 use std::sync::Arc;

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/hd_beam_search2.rs
@@ -3,12 +3,12 @@ use super::hd_search_statistics::{HdSearchResult, HdSearchStatistics};
 use crate::search_algorithm::data_structure::{exceed_bound, Beam};
 use crate::search_algorithm::util::TimeKeeper;
 use crate::search_algorithm::{
-    data_structure::{ParentAndChildStateFunctionCache, TransitionWithId},
+    data_structure::{TransitionWithId},
     get_solution_cost_and_suffix, BeamSearchParameters, BfsNode, SearchInput, Solution,
     StateRegistry,
 };
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
-use dypdl::{variable_type, Model, TransitionInterface};
+use dypdl::{variable_type, Model, ParentAndChildStateFunctionCache, TransitionInterface};
 use std::error::Error;
 use std::fmt::Display;
 use std::sync::Arc;

--- a/dypdl-heuristic-search/src/parallel_search_algorithm/shared_beam_search.rs
+++ b/dypdl-heuristic-search/src/parallel_search_algorithm/shared_beam_search.rs
@@ -2,10 +2,10 @@ use super::data_structure::{ConcurrentStateRegistry, SendableSuccessorIterator};
 use crate::search_algorithm::data_structure::{exceed_bound, HashableSignatureVariables};
 use crate::search_algorithm::util::TimeKeeper;
 use crate::search_algorithm::{
-    data_structure::{ParentAndChildStateFunctionCache, TransitionWithId},
+    data_structure::{TransitionWithId},
     get_solution_cost_and_suffix, BeamSearchParameters, BfsNode, SearchInput, Solution,
 };
-use dypdl::{variable_type, Model, ReduceFunction, TransitionInterface};
+use dypdl::{variable_type, Model, ParentAndChildStateFunctionCache, ReduceFunction, TransitionInterface};
 use rayon::prelude::*;
 use std::error::Error;
 use std::fmt::Display;

--- a/dypdl-heuristic-search/src/search_algorithm/acps.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/acps.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{print_dual_bound, update_bound_if_better, update_solution, TimeKeeper};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::cmp;
 use std::collections;
 use std::error::Error;

--- a/dypdl-heuristic-search/src/search_algorithm/apps.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/apps.rs
@@ -1,12 +1,12 @@
 use super::acps::ProgressiveSearchParameters;
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::util::{print_dual_bound, update_bound_if_better, update_solution, TimeKeeper};
 use super::{Parameters, Search, SearchInput, Solution};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::collections;
 use std::error::Error;
 use std::fmt;

--- a/dypdl-heuristic-search/src/search_algorithm/beam_search.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/beam_search.rs
@@ -1,10 +1,10 @@
 use super::data_structure::{
-    exceed_bound, Beam, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, TransitionWithId,
+    exceed_bound, Beam, BfsNode, StateRegistry, TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, SearchInput, Solution};
 use super::util::TimeKeeper;
-use dypdl::{variable_type, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, TransitionInterface};
 use std::fmt::Display;
 use std::mem;
 use std::rc::Rc;

--- a/dypdl-heuristic-search/src/search_algorithm/best_first_search.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/best_first_search.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{update_bound_if_better, update_solution, TimeKeeper};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::collections::BinaryHeap;
 use std::error::Error;
 use std::fmt;

--- a/dypdl-heuristic-search/src/search_algorithm/breadth_first_search.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/breadth_first_search.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{update_bound_if_better, update_solution, TimeKeeper};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;

--- a/dypdl-heuristic-search/src/search_algorithm/cbfs.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/cbfs.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, TransitionWithId,
+    exceed_bound, BfsNode, StateRegistry, TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{print_dual_bound, update_bound_if_better, update_solution, TimeKeeper};
 use super::SuccessorGenerator;
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::collections;
 use std::error::Error;
 use std::fmt;

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure.rs
@@ -2,7 +2,6 @@
 
 mod beam;
 mod hashable_state;
-mod parent_and_child_state_function_cache;
 mod search_node;
 mod state_registry;
 mod successor_generator;
@@ -16,7 +15,6 @@ pub use beam::{Beam, BeamDrain, BeamInsertionStatus};
 pub use hashable_state::{
     HashableSignatureVariables, HashableState, StateWithHashableSignatureVariables,
 };
-pub use parent_and_child_state_function_cache::ParentAndChildStateFunctionCache;
 pub use search_node::{
     BfsNode, BfsNodeWithTransitionIds, CostNode, CustomFNode, FNode, FNodeEvaluators, WeightedFNode,
 };

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/beam.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/beam.rs
@@ -50,11 +50,12 @@ where
 ///
 /// ```
 /// use dypdl::prelude::*;
+/// use dypdl::ParentAndChildStateFunctionCache;
 /// use dypdl_heuristic_search::search_algorithm::{
 ///     FNode, StateInRegistry, StateRegistry,
 /// };
 /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-///     Beam, GetTransitions, StateInformation, ParentAndChildStateFunctionCache,
+///     Beam, GetTransitions, StateInformation,
 ///     TransitionWithId,
 /// };
 /// use std::rc::Rc;

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/cost_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/cost_node.rs
@@ -3,7 +3,7 @@ use super::super::transition::TransitionWithId;
 use super::super::transition_chain::{CreateTransitionChain, GetTransitions, RcChain};
 use super::BfsNode;
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, ReduceFunction, StateFunctionCache, Transition, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, ReduceFunction, Transition, TransitionInterface};
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
@@ -224,7 +224,7 @@ where
 
     /// Generates a successor node given a transition and a DyPDL model.
     ///
-    /// `function_cache` is not cleared and updated by this node.
+    /// `function_cache.parent` is not cleared and updated by this node.
     ///
     /// Returns `None` if the successor state is pruned by a state constraint.
     ///
@@ -265,7 +265,7 @@ where
     ///     &model.target, &mut function_cache, &model.state_functions, &model.table_registry,
     /// );
     ///
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     /// let node = node.generate_successor_node(
     ///     Rc::new(transition.clone()), &mut function_cache, &model,
     /// );
@@ -279,10 +279,11 @@ where
     pub fn generate_successor_node(
         &self,
         transition: R,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         model: &Model,
     ) -> Option<Self> {
         let cost = self.cost(model);
+        function_cache.child.clear();
         let (state, cost) = model.generate_successor_state(
             &self.state,
             function_cache,
@@ -341,7 +342,7 @@ where
     ///     &model.target, &mut function_cache, &model.state_functions, &model.table_registry,
     /// );
     ///
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     /// let result = node.insert_successor_node(
     ///     Rc::new(transition.clone()), &mut function_cache, &mut registry,
     /// );
@@ -356,13 +357,14 @@ where
     pub fn insert_successor_node<M>(
         &self,
         transition: R,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         registry: &mut StateRegistry<T, Self, M>,
     ) -> Option<(Rc<Self>, bool)>
     where
         M: Deref<Target = Model> + Clone,
     {
         let model = registry.model().clone();
+        function_cache.child.clear();
         let (state, cost) = model.generate_successor_state(
             self.state(),
             function_cache,
@@ -719,7 +721,7 @@ mod tests {
         );
         let node = CostNode::<_>::generate_root_node(state, 0, &model);
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor =
             node.generate_successor_node(Rc::new(transition.clone()), &mut function_cache, &model);
         assert!(successor.is_some());
@@ -771,7 +773,7 @@ mod tests {
         );
         let node = CostNode::<_>::generate_root_node(state, 0, &model);
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let successor =
             node.generate_successor_node(Rc::new(transition.clone()), &mut function_cache, &model);
         assert!(successor.is_some());
@@ -818,7 +820,7 @@ mod tests {
             id: 0,
         };
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.generate_successor_node(Rc::new(transition), &mut function_cache, &model);
         assert_eq!(result, None);
     }
@@ -861,7 +863,7 @@ mod tests {
         let result = registry.insert(node.clone());
         assert!(result.information.is_some());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,
@@ -922,7 +924,7 @@ mod tests {
         let result = registry.insert(node.clone());
         assert!(result.information.is_some());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,
@@ -975,7 +977,7 @@ mod tests {
             id: 0,
         };
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result =
             node.insert_successor_node(Rc::new(transition), &mut function_cache, &mut registry);
         assert_eq!(result, None);
@@ -1020,7 +1022,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,
@@ -1082,7 +1084,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,
@@ -1136,7 +1138,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,
@@ -1176,7 +1178,7 @@ mod tests {
         let dominated = result.dominated;
         assert_eq!(dominated, SmallVec::<[_; 1]>::new());
 
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
         let result = node.insert_successor_node(
             Rc::new(transition.clone()),
             &mut function_cache,

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/custom_f_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/custom_f_node.rs
@@ -1,10 +1,10 @@
 use super::super::state_registry::{StateInRegistry, StateInformation, StateRegistry};
 use super::super::transition::{TransitionWithCustomCost, TransitionWithId};
 use super::super::transition_chain::{CreateTransitionChain, GetTransitions};
-use super::super::{ParentAndChildStateFunctionCache, RcChain};
+use super::super::RcChain;
 use super::{BfsNode, CostNode, FNodeEvaluators};
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, StateFunctionCache};
+use dypdl::{Model, ParentAndChildStateFunctionCache, StateFunctionCache};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::ops::Deref;
@@ -241,11 +241,12 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{
     ///     CustomFNode, FNodeEvaluators, StateInRegistry, TransitionWithCustomCost, TransitionWithId,
     /// };
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache,
+    ///     GetTransitions, StateInformation
     /// };
     /// use std::rc::Rc;
     ///
@@ -312,10 +313,10 @@ where
             &model.state_functions,
             &model.table_registry,
         );
+        function_cache.child.clear();
         let node =
             self.node
-                .generate_successor_node(transition, &mut function_cache.parent, model)?;
-        function_cache.child.clear();
+                .generate_successor_node(transition, function_cache, model)?;
         let h = (evaluators.h)(node.state(), &mut function_cache.child)?;
         let f = (evaluators.f)(g, h, node.state());
         let (h, f) = if maximize { (h, f) } else { (-h, -f) };
@@ -348,11 +349,12 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{
     ///     CustomFNode, FNodeEvaluators, StateInRegistry, StateRegistry, TransitionWithCustomCost,
     /// };
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId
     /// };
     /// use std::rc::Rc;
     ///
@@ -422,9 +424,10 @@ where
         F: FnOnce(U, U, &StateInRegistry) -> U,
         M: Deref<Target = Model> + Clone,
     {
+        function_cache.child.clear();
         let (state, cost) = registry.model().generate_successor_state(
             self.state(),
-            &mut function_cache.parent,
+            function_cache,
             self.cost(registry.model()),
             transition.deref(),
             None,
@@ -440,8 +443,6 @@ where
                     -other.h
                 }
             } else {
-                function_cache.child.clear();
-
                 (evaluators.h)(&state, &mut function_cache.child)?
             };
             let g = transition.transition.custom_cost.eval_cost(

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
@@ -1214,63 +1214,6 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_successor_pruned_by_constraint_containing_state_function() {
-        let mut model = Model::default();
-        let v1 = model.add_integer_resource_variable("v1", true, 0);
-        assert!(v1.is_ok());
-        let v1 = v1.unwrap();
-        let v2 = model.add_integer_resource_variable("v2", false, 0);
-        assert!(v2.is_ok());
-        let v2 = v2.unwrap();
-        let sf_v1 = model.add_integer_state_function(
-            "sf_v1", v1.into());
-        assert!(sf_v1.is_ok());
-        let sf_v1 = sf_v1.unwrap();
-
-        let result =
-            model.add_state_constraint(Condition::comparison_i(ComparisonOperator::Le, sf_v1.clone(), 0));
-        assert!(result.is_ok());
-
-        let state = model.target.clone();
-        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
-        let h_evaluator = |_: &StateInRegistry, _: &mut _| Some(0);
-        let f_evaluator = |g, h, _: &StateInRegistry| g + h;
-        let node = FNode::<_>::generate_root_node(
-            state,
-            &mut function_cache.parent,
-            0,
-            &model,
-            &h_evaluator,
-            &f_evaluator,
-            None,
-        );
-        assert!(node.is_some());
-        let node = node.unwrap();
-
-        let mut transition = Transition::default();
-        let result = transition.add_effect(v1, sf_v1 + 1);
-        assert!(result.is_ok());
-        let result = transition.add_effect(v2, v2 + 1);
-        assert!(result.is_ok());
-        transition.set_cost(IntegerExpression::Cost + 1);
-        let transition = TransitionWithId {
-            transition,
-            forced: false,
-            id: 0,
-        };
-
-        let result = node.generate_successor_node(
-            Rc::new(transition),
-            &mut function_cache,
-            &model,
-            &h_evaluator,
-            &f_evaluator,
-            None,
-        );
-        assert_eq!(result, None);
-    }
-
-    #[test]
     fn test_generate_successor_pruned_by_bound_min() {
         let mut model = Model::default();
         model.set_minimize();
@@ -1699,66 +1642,6 @@ mod tests {
 
         let mut transition = Transition::default();
         let result = transition.add_effect(v1, v1 + 1);
-        assert!(result.is_ok());
-        let result = transition.add_effect(v2, v2 + 1);
-        assert!(result.is_ok());
-        transition.set_cost(IntegerExpression::Cost + 1);
-        let transition = TransitionWithId {
-            transition,
-            forced: false,
-            id: 0,
-        };
-
-        let result = node.insert_successor_node(
-            Rc::new(transition),
-            &mut function_cache,
-            &mut registry,
-            &h_evaluator,
-            &f_evaluator,
-            None,
-        );
-        assert_eq!(result, None);
-        assert!(!node.is_closed());
-    }
-
-    #[test]
-    fn test_insert_successor_pruned_by_constraint_containing_state_function() {
-        let mut model = Model::default();
-        let v1 = model.add_integer_resource_variable("v1", true, 0);
-        assert!(v1.is_ok());
-        let v1 = v1.unwrap();
-        let v2 = model.add_integer_resource_variable("v2", false, 0);
-        assert!(v2.is_ok());
-        let v2 = v2.unwrap();
-        let sf_v1 = model.add_integer_state_function(
-            "sf_v1", v1.into());
-        assert!(sf_v1.is_ok());
-        let sf_v1 = sf_v1.unwrap();
-
-        let result =
-            model.add_state_constraint(Condition::comparison_i(ComparisonOperator::Le, sf_v1.clone(), 0));
-        assert!(result.is_ok());
-
-        let state = StateInRegistry::from(model.target.clone());
-        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
-        let mut registry = StateRegistry::<_, FNode<_>>::new(Rc::new(model.clone()));
-
-        let h_evaluator = |_: &StateInRegistry, _: &mut _| Some(0);
-        let f_evaluator = |g, h, _: &StateInRegistry| g + h;
-        let node = FNode::generate_root_node(
-            state,
-            &mut function_cache.parent,
-            0,
-            &model,
-            &h_evaluator,
-            &f_evaluator,
-            None,
-        );
-        assert!(node.is_some());
-        let node = node.unwrap();
-
-        let mut transition = Transition::default();
-        let result = transition.add_effect(v1, sf_v1 + 1);
         assert!(result.is_ok());
         let result = transition.add_effect(v2, v2 + 1);
         assert!(result.is_ok());

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
@@ -1214,6 +1214,63 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_successor_pruned_by_constraint_containing_state_function() {
+        let mut model = Model::default();
+        let v1 = model.add_integer_resource_variable("v1", true, 0);
+        assert!(v1.is_ok());
+        let v1 = v1.unwrap();
+        let v2 = model.add_integer_resource_variable("v2", false, 0);
+        assert!(v2.is_ok());
+        let v2 = v2.unwrap();
+        let sf_v1 = model.add_integer_state_function(
+            "sf_v1", v1.into());
+        assert!(sf_v1.is_ok());
+        let sf_v1 = sf_v1.unwrap();
+
+        let result =
+            model.add_state_constraint(Condition::comparison_i(ComparisonOperator::Le, sf_v1.clone(), 0));
+        assert!(result.is_ok());
+
+        let state = model.target.clone();
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
+        let h_evaluator = |_: &StateInRegistry, _: &mut _| Some(0);
+        let f_evaluator = |g, h, _: &StateInRegistry| g + h;
+        let node = FNode::<_>::generate_root_node(
+            state,
+            &mut function_cache.parent,
+            0,
+            &model,
+            &h_evaluator,
+            &f_evaluator,
+            None,
+        );
+        assert!(node.is_some());
+        let node = node.unwrap();
+
+        let mut transition = Transition::default();
+        let result = transition.add_effect(v1, sf_v1 + 1);
+        assert!(result.is_ok());
+        let result = transition.add_effect(v2, v2 + 1);
+        assert!(result.is_ok());
+        transition.set_cost(IntegerExpression::Cost + 1);
+        let transition = TransitionWithId {
+            transition,
+            forced: false,
+            id: 0,
+        };
+
+        let result = node.generate_successor_node(
+            Rc::new(transition),
+            &mut function_cache,
+            &model,
+            &h_evaluator,
+            &f_evaluator,
+            None,
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
     fn test_generate_successor_pruned_by_bound_min() {
         let mut model = Model::default();
         model.set_minimize();
@@ -1642,6 +1699,66 @@ mod tests {
 
         let mut transition = Transition::default();
         let result = transition.add_effect(v1, v1 + 1);
+        assert!(result.is_ok());
+        let result = transition.add_effect(v2, v2 + 1);
+        assert!(result.is_ok());
+        transition.set_cost(IntegerExpression::Cost + 1);
+        let transition = TransitionWithId {
+            transition,
+            forced: false,
+            id: 0,
+        };
+
+        let result = node.insert_successor_node(
+            Rc::new(transition),
+            &mut function_cache,
+            &mut registry,
+            &h_evaluator,
+            &f_evaluator,
+            None,
+        );
+        assert_eq!(result, None);
+        assert!(!node.is_closed());
+    }
+
+    #[test]
+    fn test_insert_successor_pruned_by_constraint_containing_state_function() {
+        let mut model = Model::default();
+        let v1 = model.add_integer_resource_variable("v1", true, 0);
+        assert!(v1.is_ok());
+        let v1 = v1.unwrap();
+        let v2 = model.add_integer_resource_variable("v2", false, 0);
+        assert!(v2.is_ok());
+        let v2 = v2.unwrap();
+        let sf_v1 = model.add_integer_state_function(
+            "sf_v1", v1.into());
+        assert!(sf_v1.is_ok());
+        let sf_v1 = sf_v1.unwrap();
+
+        let result =
+            model.add_state_constraint(Condition::comparison_i(ComparisonOperator::Le, sf_v1.clone(), 0));
+        assert!(result.is_ok());
+
+        let state = StateInRegistry::from(model.target.clone());
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
+        let mut registry = StateRegistry::<_, FNode<_>>::new(Rc::new(model.clone()));
+
+        let h_evaluator = |_: &StateInRegistry, _: &mut _| Some(0);
+        let f_evaluator = |g, h, _: &StateInRegistry| g + h;
+        let node = FNode::generate_root_node(
+            state,
+            &mut function_cache.parent,
+            0,
+            &model,
+            &h_evaluator,
+            &f_evaluator,
+            None,
+        );
+        assert!(node.is_some());
+        let node = node.unwrap();
+
+        let mut transition = Transition::default();
+        let result = transition.add_effect(v1, sf_v1 + 1);
         assert!(result.is_ok());
         let result = transition.add_effect(v2, v2 + 1);
         assert!(result.is_ok());

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/f_node.rs
@@ -2,11 +2,10 @@ use super::super::state_registry::{StateInRegistry, StateInformation, StateRegis
 use super::super::transition::TransitionWithId;
 use super::super::transition_chain::{CreateTransitionChain, GetTransitions, RcChain};
 use super::super::util::exceed_bound;
-use super::super::ParentAndChildStateFunctionCache;
 use super::{BfsNode, CostNode};
 use dypdl::variable_type::Numeric;
 use dypdl::{
-    Model, ReduceFunction, StateFunctionCache, StateInterface, Transition, TransitionInterface,
+    Model, ParentAndChildStateFunctionCache, ReduceFunction, StateFunctionCache, StateInterface, Transition, TransitionInterface,
 };
 use std::cmp::Ordering;
 use std::fmt::Display;
@@ -175,6 +174,9 @@ where
     /// If the model is minimizing, the h- and f-values become the negatives of the values returned by the evaluators.
     /// If the model is maximizing, the h- and f-values become the values returned by the evaluators.
     /// If `other` is given, the h-value is taken from it.
+    ///
+    /// Note that the caller must guarantee that the cache is consistent with the state.
+    /// Clearing the cache guarantees consistency; it triggers lazy recomputations syncing the cache and the state.
     pub fn evaluate_state<S, H, F>(
         state: &S,
         function_cache: &mut StateFunctionCache,
@@ -196,8 +198,6 @@ where
                 -other.h
             }
         } else {
-            function_cache.clear();
-
             (evaluators.h)(state, function_cache)?
         };
         let f = (evaluators.f)(g, h, state);
@@ -308,9 +308,10 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{FNode, StateInRegistry};
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId
     /// };
     /// use std::rc::Rc;
     ///
@@ -367,9 +368,10 @@ where
         H: FnOnce(&StateInRegistry, &mut StateFunctionCache) -> Option<T>,
         F: FnOnce(T, T, &StateInRegistry) -> T,
     {
+        function_cache.child.clear();
         let (state, g) = model.generate_successor_state(
             self.state(),
-            &mut function_cache.parent,
+            function_cache,
             self.cost(model),
             transition.deref(),
             None,
@@ -420,9 +422,10 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{FNode, StateInRegistry, StateRegistry};
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId
     /// };
     /// use std::rc::Rc;
     ///
@@ -483,9 +486,10 @@ where
         F: FnOnce(T, T, &StateInRegistry) -> T,
         M: Deref<Target = Model> + Clone,
     {
+        function_cache.child.clear();
         let (state, g) = registry.model().generate_successor_state(
             self.state(),
-            &mut function_cache.parent,
+            function_cache,
             self.cost(registry.model()),
             transition.deref(),
             None,

--- a/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/weighted_f_node.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/data_structure/search_node/weighted_f_node.rs
@@ -1,10 +1,9 @@
 use super::super::state_registry::{StateInRegistry, StateInformation, StateRegistry};
 use super::super::transition::TransitionWithId;
 use super::super::transition_chain::{CreateTransitionChain, GetTransitions, RcChain};
-use super::super::ParentAndChildStateFunctionCache;
 use super::{BfsNode, CostNode, FNode, FNodeEvaluators};
 use dypdl::{
-    variable_type::Numeric, Model, ReduceFunction, StateFunctionCache, Transition,
+    variable_type::Numeric, Model, ParentAndChildStateFunctionCache, ReduceFunction, StateFunctionCache, Transition,
     TransitionInterface,
 };
 use std::cmp::Ordering;
@@ -270,11 +269,12 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{
     ///     FNodeEvaluators, StateInRegistry, WeightedFNode,
     /// };
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId,
     /// };
     /// use std::rc::Rc;
     ///
@@ -380,11 +380,12 @@ where
     ///
     /// ```
     /// use dypdl::prelude::*;
+    /// use dypdl::ParentAndChildStateFunctionCache;
     /// use dypdl_heuristic_search::search_algorithm::{
     ///     FNodeEvaluators, StateInRegistry, StateRegistry, WeightedFNode,
     /// };
     /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-    ///     GetTransitions, StateInformation, ParentAndChildStateFunctionCache, TransitionWithId,
+    ///     GetTransitions, StateInformation, TransitionWithId,
     /// };
     /// use std::rc::Rc;
     ///
@@ -459,9 +460,10 @@ where
         F: FnOnce(T, T, &StateInRegistry) -> U,
         M: Deref<Target = Model> + Clone,
     {
+        function_cache.child.clear();
         let (state, g) = registry.model().generate_successor_state(
             self.state(),
-            &mut function_cache.parent,
+            function_cache,
             self.cost(registry.model()),
             transition.deref(),
             None,

--- a/dypdl-heuristic-search/src/search_algorithm/dbdfs.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/dbdfs.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{print_dual_bound, update_bound_if_better, update_solution, TimeKeeper};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::error::Error;
 use std::fmt;
 use std::mem;

--- a/dypdl-heuristic-search/src/search_algorithm/dd_lns.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/dd_lns.rs
@@ -1,6 +1,6 @@
 use super::beam_search::BeamSearchParameters;
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateInRegistry, StateRegistry,
+    exceed_bound, BfsNode, StateInRegistry, StateRegistry,
     TransitionMutex, TransitionWithId,
 };
 use super::neighborhood_search::NeighborhoodSearchInput;
@@ -8,7 +8,7 @@ use super::randomized_restricted_dd::{randomized_restricted_dd, RandomizedRestri
 use super::rollout::get_trace;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{print_primal_bound, update_bound_if_better, TimeKeeper};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 use std::error::Error;

--- a/dypdl-heuristic-search/src/search_algorithm/dfbb.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/dfbb.rs
@@ -1,11 +1,11 @@
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, SuccessorGenerator,
+    exceed_bound, BfsNode, StateRegistry, SuccessorGenerator,
     TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{Parameters, Search, SearchInput, Solution};
 use super::util::{self, print_dual_bound, update_bound_if_better, update_solution};
-use dypdl::{variable_type, Transition, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, Transition, TransitionInterface};
 use std::error::Error;
 use std::fmt;
 use std::rc::Rc;

--- a/dypdl-heuristic-search/src/search_algorithm/randomized_restricted_dd.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/randomized_restricted_dd.rs
@@ -1,11 +1,11 @@
 use super::beam_search::BeamSearchParameters;
 use super::data_structure::{
-    exceed_bound, BfsNode, ParentAndChildStateFunctionCache, StateRegistry, TransitionWithId,
+    exceed_bound, BfsNode, StateRegistry, TransitionWithId,
 };
 use super::rollout::get_solution_cost_and_suffix;
 use super::search::{SearchInput, Solution};
 use super::util;
-use dypdl::{variable_type, TransitionInterface};
+use dypdl::{variable_type, ParentAndChildStateFunctionCache, TransitionInterface};
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 use std::cmp;

--- a/dypdl-heuristic-search/src/search_algorithm/rollout.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/rollout.rs
@@ -1,7 +1,7 @@
-use super::data_structure::{ParentAndChildStateFunctionCache, StateInformation};
+use super::data_structure::{StateInformation};
 use super::StateInRegistry;
 use dypdl::variable_type::Numeric;
-use dypdl::{Model, State, StateFunctionCache, StateInterface, TransitionInterface};
+use dypdl::{Model, ParentAndChildStateFunctionCache, State, StateFunctionCache, StateInterface, TransitionInterface};
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -39,9 +39,8 @@ where
 ///
 /// ```
 /// use dypdl::prelude::*;
-/// use dypdl_heuristic_search::search_algorithm::{
-///     data_structure::ParentAndChildStateFunctionCache, rollout,
-/// };
+/// use dypdl::ParentAndChildStateFunctionCache;
+/// use dypdl_heuristic_search::search_algorithm::rollout;
 ///
 /// let mut model = Model::default();
 /// let variable = model.add_integer_variable("variable", 1).unwrap();
@@ -194,9 +193,9 @@ where
 ///
 /// ```
 /// use dypdl::prelude::*;
+/// use dypdl::ParentAndChildStateFunctionCache;
 /// use dypdl_heuristic_search::Solution;
 /// use dypdl_heuristic_search::search_algorithm::{
-///     data_structure::ParentAndChildStateFunctionCache,
 ///     FNode, StateInRegistry, get_solution_cost_and_suffix,
 /// };
 /// use dypdl_heuristic_search::search_algorithm::data_structure::{

--- a/dypdl-heuristic-search/src/search_algorithm/util.rs
+++ b/dypdl-heuristic-search/src/search_algorithm/util.rs
@@ -119,12 +119,13 @@ where
 ///
 /// ```
 /// use dypdl::prelude::*;
+/// use dypdl::ParentAndChildStateFunctionCache;
 /// use dypdl_heuristic_search::Solution;
 /// use dypdl_heuristic_search::search_algorithm::{
 ///     FNode, StateInRegistry, get_solution_cost_and_suffix,
 /// };
 /// use dypdl_heuristic_search::search_algorithm::data_structure::{
-///     GetTransitions, ParentAndChildStateFunctionCache, TransitionWithId,
+///     GetTransitions, TransitionWithId,
 /// };
 /// use dypdl_heuristic_search::search_algorithm::util::update_solution;
 /// use std::rc::Rc;
@@ -252,9 +253,10 @@ pub fn update_bound_if_better<T, V>(
 #[cfg(test)]
 mod tests {
     use super::super::data_structure::{
-        FNode, ParentAndChildStateFunctionCache, StateInRegistry, TransitionWithId,
+        FNode, StateInRegistry, TransitionWithId,
     };
     use super::*;
+    use dypdl::ParentAndChildStateFunctionCache;
     use dypdl::prelude::*;
     use std::rc::Rc;
 

--- a/dypdl/Cargo.toml
+++ b/dypdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dypdl"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.65"
 description = "Libarary for Dynamic Programming Description Language (DyPDL)."

--- a/dypdl/src/lib.rs
+++ b/dypdl/src/lib.rs
@@ -4621,6 +4621,72 @@ mod tests {
     }
 
     #[test]
+    fn generate_successor_state_pruned_by_constraint_containing_state_function() {
+        let state = State {
+            signature_variables: SignatureVariables {
+                integer_variables: vec![0],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let transition = Transition {
+            name: String::from("increase"),
+            effect: Effect {
+                integer_effects: vec![(
+                    0,
+                    IntegerExpression::BinaryOperation(
+                        BinaryOperator::Add,
+                        Box::new(IntegerExpression::Variable(0)),
+                        Box::new(IntegerExpression::BinaryOperation(
+                            BinaryOperator::Add,
+                            Box::new(IntegerExpression::StateFunction(0)),
+                            Box::new(IntegerExpression::Constant(1)),
+                        )),
+                    ),
+                )],
+                ..Default::default()
+            },
+            cost: CostExpression::Integer(IntegerExpression::BinaryOperation(
+                BinaryOperator::Add,
+                Box::new(IntegerExpression::Cost),
+                Box::new(IntegerExpression::Constant(1)),
+            )),
+            ..Default::default()
+        };
+        let name_to_integer_variable = FxHashMap::default();
+        let model = Model {
+            state_metadata: StateMetadata {
+                integer_variable_names: vec![String::from("v1")],
+                name_to_integer_variable,
+                ..Default::default()
+            },
+            target: state.clone(),
+            state_functions: StateFunctions{
+                integer_function_names: vec!["sf_v1".to_string()],
+                name_to_integer_function: [("sf_v1".to_string(), 0)].into_iter().collect(),
+                integer_functions: vec![IntegerExpression::Variable(0)],
+                ..Default::default()
+            },
+            state_constraints: vec![GroundedCondition {
+                condition: Condition::ComparisonI(
+                    ComparisonOperator::Le,
+                    Box::new(IntegerExpression::StateFunction(0)),
+                    Box::new(IntegerExpression::Constant(0)),
+                ),
+                ..Default::default()
+            }],
+            forward_transitions: vec![transition.clone()],
+            ..Default::default()
+        };
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
+
+        let result: Option<(State, _)> =
+            model.generate_successor_state(&state, &mut function_cache, 0, &transition, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
     fn validate_forward_true() {
         let name_to_integer_variable = FxHashMap::default();
         let model = Model {

--- a/dypdl/src/lib.rs
+++ b/dypdl/src/lib.rs
@@ -130,6 +130,7 @@ mod base_case;
 mod effect;
 pub mod expression;
 mod grounded_condition;
+mod parent_and_child_state_function_cache;
 mod state;
 mod state_functions;
 mod table;
@@ -142,6 +143,7 @@ pub mod variable_type;
 pub use base_case::BaseCase;
 pub use effect::Effect;
 pub use grounded_condition::GroundedCondition;
+pub use parent_and_child_state_function_cache::ParentAndChildStateFunctionCache;
 pub use state::{
     AccessPreference, CheckVariable, ContinuousResourceVariable, ContinuousVariable,
     ElementResourceVariable, ElementVariable, GetObjectTypeOf, IntegerResourceVariable,
@@ -175,6 +177,7 @@ pub mod prelude {
         ContinuousStateFunction, ContinuousVariable, CostExpression, CostType, Element,
         ElementResourceVariable, ElementStateFunction, ElementVariable, GetObjectTypeOf, Integer,
         IntegerResourceVariable, IntegerStateFunction, IntegerVariable, Model, ObjectType,
+        ParentAndChildStateFunctionCache,
         ReduceFunction, ResourceVariables, Set, SetStateFunction, SetVariable, SignatureVariables,
         State, StateFunctionCache, StateFunctions, StateInterface, StateMetadata, Table1DHandle,
         Table2DHandle, Table3DHandle, TableHandle, TableInterface, Transition, TransitionId,
@@ -493,6 +496,9 @@ impl Model {
 
     /// Returns the successor state and the cost of a state, given a transition and the cost of the successor state.
     ///
+    /// Note that the caller must guarantee that the cache is consistent with the parent and child states.
+    /// Clearing the cache guarantees consistency; it triggers lazy recomputations syncing the cache and the state.
+    ///
     /// Returns `None` if the cost is greater than or equal to the bound.
     ///
     /// # Panics
@@ -507,7 +513,7 @@ impl Model {
     /// let mut model = Model::default();
     /// let variable = model.add_integer_variable("variable", 2).unwrap();
     /// let state = model.target.clone();
-    /// let mut function_cache = StateFunctionCache::new(&model.state_functions);
+    /// let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
     ///
     /// let mut transition = Transition::new("transition");
     /// transition.add_effect(variable, variable + 1);
@@ -532,26 +538,26 @@ impl Model {
     >(
         &self,
         state: &S,
-        function_cache: &mut StateFunctionCache,
+        function_cache: &mut ParentAndChildStateFunctionCache,
         cost: U,
         transition: &T,
         cost_bound: Option<U>,
     ) -> Option<(R, U)> {
         let successor = transition.apply(
             state,
-            function_cache,
+            &mut function_cache.parent,
             &self.state_functions,
             &self.table_registry,
         );
 
-        if !self.check_constraints(&successor, function_cache) {
+        if !self.check_constraints(&successor, &mut function_cache.child) {
             return None;
         }
 
         let successor_cost = transition.eval_cost(
             cost,
             state,
-            function_cache,
+            &mut function_cache.parent,
             &self.state_functions,
             &self.table_registry,
         );
@@ -4324,7 +4330,7 @@ mod tests {
             forward_transitions: vec![transition.clone()],
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, None);
@@ -4384,7 +4390,7 @@ mod tests {
             reduce_function: ReduceFunction::Min,
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, Some(2));
@@ -4444,7 +4450,7 @@ mod tests {
             reduce_function: ReduceFunction::Max,
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, Some(0));
@@ -4504,7 +4510,7 @@ mod tests {
             reduce_function: ReduceFunction::Min,
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result: Option<(State, _)> =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, Some(1));
@@ -4552,7 +4558,7 @@ mod tests {
             reduce_function: ReduceFunction::Max,
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result: Option<(State, _)> =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, Some(1));
@@ -4607,7 +4613,7 @@ mod tests {
             forward_transitions: vec![transition.clone()],
             ..Default::default()
         };
-        let mut function_cache = StateFunctionCache::new(&model.state_functions);
+        let mut function_cache = ParentAndChildStateFunctionCache::new(&model.state_functions);
 
         let result: Option<(State, _)> =
             model.generate_successor_state(&state, &mut function_cache, 0, &transition, None);

--- a/dypdl/src/parent_and_child_state_function_cache.rs
+++ b/dypdl/src/parent_and_child_state_function_cache.rs
@@ -1,4 +1,4 @@
-use dypdl::prelude::*;
+use crate::{StateFunctionCache, StateFunctions};
 
 /// Parent and child caches for state functions.
 #[derive(Clone, Debug, Default, PartialEq)]


### PR DESCRIPTION
Fixes #39

Changed the type of `function_cache` which is the argument to the successor generator to `ParentAndChildStateFunctionCache`. 

Called `function_cache.child.clear()` in the method invoking `generate_successor_state`.

Since, the `dypdl` package cannot depend on the `dypdl-heuristic-search` package, moved the `ParentAndChildStateFunctionCache` from the `dypdl-heuristic-search` to the `dypdl`.